### PR TITLE
Add edit entry feature

### DIFF
--- a/client/add/index.html
+++ b/client/add/index.html
@@ -24,7 +24,12 @@
         <div class="mb-3">
             <a href="/" class="btn btn-outline-primary">← Back to Charts</a>
         </div>
-        <form>
+
+        <div id="editModeHeading" style="display:none;" class="mb-3">
+            <h4>Editing: <span id="editMovieTitle"></span></h4>
+        </div>
+
+        <form id="searchForm">
             <div class="row">
                 <div class="col-12">
                     <div class="position-relative">
@@ -163,6 +168,7 @@
             <div class="row custom-control custom-button">
                 <div class="col-12 position-relative">
                     <button id="formSubmit" type="button" class="btn btn-primary" disabled="disabled">Submit</button>
+                    <div id="editSuccessMsg" class="alert alert-success mt-2" style="display:none;">Entry updated successfully.</div>
                 </div>
             </div>
         </form>

--- a/client/css/main.css
+++ b/client/css/main.css
@@ -441,6 +441,34 @@ body.dark-mode .movie-table tr:hover {
     white-space: nowrap;
 }
 
+.movie-table td.edit-cell {
+    white-space: nowrap;
+    width: 1%;
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+a.edit-entry-link {
+    font-size: 0.85em;
+    color: #aaa;
+    text-decoration: none;
+    opacity: 0.6;
+}
+
+a.edit-entry-link:hover {
+    opacity: 1;
+    color: #555;
+    text-decoration: none;
+}
+
+body.dark-mode a.edit-entry-link {
+    color: #888;
+}
+
+body.dark-mode a.edit-entry-link:hover {
+    color: #ccc;
+}
+
 .movie-table th {
     background-color: #f5f5f5;
     font-weight: bold;

--- a/client/index.html
+++ b/client/index.html
@@ -70,6 +70,7 @@
                             <th>Review</th>
                             <th>Viewing Date</th>
                             <th>Location</th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody>

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -868,11 +868,19 @@ var prepareListData = function(data) {
         var reviewCell = $("<td />").text(row.movieReview);
         var viewingDateCell = $("<td />").addClass("viewing-date-cell").text(row.viewingDate ? row.viewingDate.slice(0, 10) : "");
         var locationCell = $("<td />").addClass("location-cell").text(row.viewLocation || "");
+        var editLink = $("<a />", {
+            'href': '/add?edit=' + row.id,
+            'text': '✏',
+            'title': 'Edit entry',
+            'class': 'edit-entry-link'
+        });
+        var editCell = $("<td />").addClass("edit-cell").append(editLink);
         var rowElem = $("<tr />")
             .append(titleCell)
             .append(reviewCell)
             .append(viewingDateCell)
-            .append(locationCell);
+            .append(locationCell)
+            .append(editCell);
         $("#movieList tbody").append(rowElem);
     });
 };

--- a/server/__tests__/endpoints.test.js
+++ b/server/__tests__/endpoints.test.js
@@ -21,7 +21,7 @@ describe('Movie API Endpoints', () => {
     it('should return movies for the current year', async () => {
       const mockMovies = [
         {
-          id: 1,
+          id: BigInt(1),
           movieTitle: 'Test Movie',
           viewingDate: new Date('2024-01-01'),
           movieURL: 'https://www.imdb.com/title/tt1234567/',


### PR DESCRIPTION
## Summary

- Adds a ✏ edit button to each row in the dashboard film list, linking to the Add UI in edit mode
- New backend endpoints: `GET /api/entry/:id` and `PUT /api/entry/:id` (both auth-protected via API key)
- Edit mode in the Add UI pre-populates all fields from the existing entry, hides the TMDB search section, and shows an in-place success message on save

## Changes

**Backend (`server/index.js`)**
- `GET /api/` now includes `id` in each row's response
- `GET /api/entry/:id` — fetch a single entry by primary key (401/404 handling)
- `PUT /api/entry/:id` — update an existing entry; validates required fields, returns 400/404/503 as appropriate

**Dashboard (`client/`)**
- Empty `<th>` added to movie table header
- `prepareListData` appends a styled `✏` link per row pointing to `/add?edit=<id>`
- CSS for `.edit-cell` / `a.edit-entry-link` with dark mode variants

**Add UI (`client/add/`)**
- `getQueryParam()` helper added
- When `?edit=<id>` is in the URL: search form hidden, heading shows movie title, all form fields pre-populated, submit button reads "Save Changes", form submits to `PUT /api/entry/:id`, success shown inline

## Test Plan

- [ ] All 23 server tests pass (`npx jest`)
- [ ] Dashboard shows ✏ icon on each film row
- [ ] Clicking ✏ while unauthenticated redirects to Authentik login
- [ ] Clicking ✏ while authenticated opens Add UI with all fields pre-populated
- [ ] Saving changes updates the record and shows "Entry updated successfully"
- [ ] TMDB search section is hidden in edit mode
- [ ] Normal Add flow (no `?edit=` param) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)