### PR TITLE
refactor: follow-up cleanup after Bootstrap 5 migration

### DIFF
--- a/client/add/js/main.js
+++ b/client/add/js/main.js
@@ -187,7 +187,7 @@ $(document).ready(function() {
     $("#lookupId").on("change", function(e) {
 		var id = $("#lookupId").val();
 
-        extractedId = id.match(/([0-9]+)/gm);
+        var extractedId = id.match(/([0-9]+)/gm);
         if(extractedId) {
             id = extractedId[0];
         }
@@ -249,6 +249,73 @@ $(document).ready(function() {
         // Normal add mode submit handler (auth via Authentik header)
         $('#formSubmit').click(handleAddSubmit);
     }
+
+    // Advanced Filters: load saved state and wire up interactions
+    loadAdvancedFilters();
+
+    $('#advancedFilters').on('show.bs.collapse', function () {
+        var button = $('button[data-bs-target="#advancedFilters"]');
+        var badge = button.find('.badge');
+        var baseText = 'Filters ▲';
+        if (badge.length > 0) {
+            button.html(baseText + ' <span class="badge bg-primary ms-1">' + badge.text() + '</span>');
+        } else {
+            button.html(baseText);
+        }
+    });
+
+    $('#advancedFilters').on('hide.bs.collapse', function () {
+        var button = $('button[data-bs-target="#advancedFilters"]');
+        var badge = button.find('.badge');
+        var baseText = 'Filters ▼';
+        if (badge.length > 0) {
+            button.html(baseText + ' <span class="badge bg-primary ms-1">' + badge.text() + '</span>');
+        } else {
+            button.html(baseText);
+        }
+    });
+
+    $('#clearFilters').on('click', function() {
+        $('#excludeVideos').prop('checked', false);
+        $('#minPopularity').val('');
+        $('#maxPopularity').val('');
+        $('#minVoteCount').val('');
+        $('#maxVoteCount').val('');
+        $('#minVoteAverage').val('');
+        $('#maxVoteAverage').val('');
+        $('#minReleaseDate').val('');
+        $('#maxReleaseDate').val('');
+        localStorage.removeItem('advancedFilters');
+        var searchTerm = $("#searchName").val().trim();
+        if (searchTerm) {
+            searchMovie(searchTerm);
+        }
+    });
+
+    var filterFields = [
+        '#excludeVideos',
+        '#minPopularity',
+        '#maxPopularity',
+        '#minVoteCount',
+        '#maxVoteCount',
+        '#minVoteAverage',
+        '#maxVoteAverage',
+        '#minReleaseDate',
+        '#maxReleaseDate'
+    ];
+
+    filterFields.forEach(function(selector) {
+        $(selector).on('change input', function() {
+            saveAdvancedFilters();
+            var searchTerm = $("#searchName").val().trim();
+            if (searchTerm) {
+                clearTimeout(window.searchTimeout);
+                window.searchTimeout = setTimeout(function() {
+                    searchMovie(searchTerm);
+                }, 300);
+            }
+        });
+    });
 });
 
 var updateViewLocations = function(viewItem) {
@@ -497,82 +564,3 @@ var loadAdvancedFilters = function() {
     }
 };
 
-// Advanced Filters functionality
-$(document).ready(function() {
-    // Load saved filters on page load
-    loadAdvancedFilters();
-    
-    // Handle collapsible toggle button text
-    $('#advancedFilters').on('show.bs.collapse', function () {
-        var button = $('button[data-bs-target="#advancedFilters"]');
-        var badge = button.find('.badge');
-        var baseText = 'Filters ▲';
-        if (badge.length > 0) {
-            button.html(baseText + ' <span class="badge bg-primary ms-1">' + badge.text() + '</span>');
-        } else {
-            button.html(baseText);
-        }
-    });
-    
-    $('#advancedFilters').on('hide.bs.collapse', function () {
-        var button = $('button[data-bs-target="#advancedFilters"]');
-        var badge = button.find('.badge');
-        var baseText = 'Filters ▼';
-        if (badge.length > 0) {
-            button.html(baseText + ' <span class="badge bg-primary ms-1">' + badge.text() + '</span>');
-        } else {
-            button.html(baseText);
-        }
-    });
-    
-    // Clear all filters functionality
-    $('#clearFilters').on('click', function() {
-        $('#excludeVideos').prop('checked', false);
-        $('#minPopularity').val('');
-        $('#maxPopularity').val('');
-        $('#minVoteCount').val('');
-        $('#maxVoteCount').val('');
-        $('#minVoteAverage').val('');
-        $('#maxVoteAverage').val('');
-        $('#minReleaseDate').val('');
-        $('#maxReleaseDate').val('');
-        
-        // Clear saved filters from localStorage
-        localStorage.removeItem('advancedFilters');
-        
-        // Trigger search after clearing if there's a search term
-        var searchTerm = $("#searchName").val().trim();
-        if (searchTerm) {
-            searchMovie(searchTerm);
-        }
-    });
-    
-    // Auto-search when filter fields change
-    var filterFields = [
-        '#excludeVideos',
-        '#minPopularity', 
-        '#maxPopularity',
-        '#minVoteCount',
-        '#maxVoteCount', 
-        '#minVoteAverage',
-        '#maxVoteAverage',
-        '#minReleaseDate',
-        '#maxReleaseDate'
-    ];
-    
-    filterFields.forEach(function(selector) {
-        $(selector).on('change input', function() {
-            // Save filters to localStorage whenever they change
-            saveAdvancedFilters();
-            
-            var searchTerm = $("#searchName").val().trim();
-            if (searchTerm) {
-                // Small delay to avoid too many requests while typing
-                clearTimeout(window.searchTimeout);
-                window.searchTimeout = setTimeout(function() {
-                    searchMovie(searchTerm);
-                }, 300);
-            }
-        });
-    });
-});

--- a/client/css/main.css
+++ b/client/css/main.css
@@ -155,7 +155,7 @@ body.dark-mode textarea::placeholder {
     color: #9aa0a6 !important;
 }
 body.dark-mode label,
-body.dark-mode .custom-control-label {
+body.dark-mode .form-check-label {
     color: #e0e0e0 !important;
 }
 body.dark-mode .dropdown-menu {
@@ -655,12 +655,12 @@ button[data-bs-target="#advancedFilters"] {
         box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
     }
     
-    #advancedFilters .custom-control-input:checked ~ .custom-control-label::before {
+    #advancedFilters .form-check-input:checked ~ .form-check-label::before {
         background-color: var(--bs-primary, #0d6efd);
         border-color: var(--bs-primary, #0d6efd);
     }
     
-    #advancedFilters .custom-control-label {
+    #advancedFilters .form-check-label {
         color: var(--bs-body-color, #fff);
     }
 }
@@ -688,12 +688,12 @@ button[data-bs-target="#advancedFilters"] {
     box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
 }
 
-[data-bs-theme="dark"] #advancedFilters .custom-control-input:checked ~ .custom-control-label::before {
+[data-bs-theme="dark"] #advancedFilters .form-check-input:checked ~ .form-check-label::before {
     background-color: var(--bs-primary, #0d6efd);
     border-color: var(--bs-primary, #0d6efd);
 }
 
-[data-bs-theme="dark"] #advancedFilters .custom-control-label {
+[data-bs-theme="dark"] #advancedFilters .form-check-label {
     color: var(--bs-body-color, #fff);
 }
 
@@ -720,12 +720,12 @@ body.dark-mode #advancedFilters .form-control:focus {
     box-shadow: 0 0 0 0.25rem rgba(49, 130, 206, 0.25);
 }
 
-body.dark-mode #advancedFilters .custom-control-input:checked ~ .custom-control-label::before {
+body.dark-mode #advancedFilters .form-check-input:checked ~ .form-check-label::before {
     background-color: #3182ce;
     border-color: #3182ce;
 }
 
-body.dark-mode #advancedFilters .custom-control-label {
+body.dark-mode #advancedFilters .form-check-label {
     color: #e2e8f0;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #4 and #5. Cleans up issues found during code review:

- `client/css/main.css`: updated stale `custom-control-input` / `custom-control-label` selectors to Bootstrap 5 equivalents (`form-check-input` / `form-check-label`)
- `client/add/js/main.js`: declared `extractedId` with `var` (was an implicit global)
- `client/add/js/main.js`: merged the two separate `$(document).ready()` blocks into one

## Test plan

- [ ] `/add` page loads correctly
- [ ] Advanced filter panel opens/closes
- [ ] Checkbox styling correct in dark mode
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)